### PR TITLE
Update JCloudsStorageModule.java

### DIFF
--- a/bundles/target/src/main/java/org/jscsi/target/storage/JCloudsStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/JCloudsStorageModule.java
@@ -193,7 +193,7 @@ public class JCloudsStorageModule implements IStorageModule {
      */
     @Override
     public long getSizeInBlocks() {
-        return mNumberOfCluster * VIRTUAL_BLOCK_SIZE;
+        return mNumberOfCluster * BLOCK_IN_CLUSTER;
     }
 
     /**


### PR DESCRIPTION
getSizeInBlocks() returns the virtual blocks in the cloud side. There are 1048576 virtual blocks as stated in JCloudsStorageModule construtor, and there are 1048576/ BLOCK_IN_CLUSTER = mNumberOfCluster clusters.
So size in virtual blocks should be  mNumberOfCluster \* BLOCK_IN_CLUSTER. It is coincidence that BLOCK_IN_CLUSTER and VIRTUAL_BLOCK_SIZE are equal. By the way, the cloud storage size is 1049576(virtual blocks) \* 512(VIRTUAL_BLOCK_SIZE) = 536870912 bytes.~= 536M
ps:Cluster and blocks are confusing,as i am using s3 api.cluster is equal to object in s3.
