### PR TITLE
Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/bundles/target/src/main/java/org/jscsi/target/Activator.java
+++ b/bundles/target/src/main/java/org/jscsi/target/Activator.java
@@ -41,14 +41,14 @@ public class Activator implements BundleActivator {
             Files.copy(context.getBundle().getResource("/jscsi-target.xsd").openStream(), schemaFile.toPath());
         }
         
-        System.out.println("Schemafile: " + ((schemaFile.exists())? "exists" : "does not exist"));
+        System.out.println("Schemafile: " + (schemaFile.exists() ? "exists" : "does not exist"));
         
         File configFile = new File("jscsi-target.xml");
         if(configFile.exists() == false){
             Files.copy(context.getBundle().getResource("/jscsi-target.xml").openStream(), configFile.toPath());
         }
         
-        System.out.println("Configfile: " + ((configFile.exists())? "exists" : "does not exist"));
+        System.out.println("Configfile: " + (configFile.exists() ? "exists" : "does not exist"));
 
         target = new TargetServer(Configuration.create(schemaFile, configFile, addr.getHostAddress()));
 

--- a/bundles/target/src/main/java/org/jscsi/target/Configuration.java
+++ b/bundles/target/src/main/java/org/jscsi/target/Configuration.java
@@ -305,7 +305,7 @@ public class Configuration {
         boolean create = true;
         if (nextNode.getLocalName().equals(ELEMENT_CREATE)) {
             Node sizeAttribute = nextNode.getAttributes().getNamedItem(ATTRIBUTE_SIZE);
-            storageLength = Math.round(((Double.valueOf(sizeAttribute.getTextContent())) * Math.pow(1024, 3)));
+            storageLength = Math.round(Double.valueOf(sizeAttribute.getTextContent()) * Math.pow(1024, 3));
         } else {
             storageLength = new File(storageFilePath).length();
             create = false;

--- a/bundles/target/src/main/java/org/jscsi/target/Target.java
+++ b/bundles/target/src/main/java/org/jscsi/target/Target.java
@@ -40,7 +40,7 @@ public class Target {
     public int hashCode () {
         final int prime = 31;
         int result = 1;
-        result = prime + ((targetName == null) ? 0 : targetName.hashCode());
+        result = prime + (targetName == null ? 0 : targetName.hashCode());
         return result;
     }
 

--- a/bundles/target/src/main/java/org/jscsi/target/connection/TargetPduFactory.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/TargetPduFactory.java
@@ -80,7 +80,7 @@ public class TargetPduFactory {
         bhs.setInitiatorTaskTag(initiatorTaskTag);
         parser.setTime2Wait(time2Wait);
         parser.setTime2Retain(time2Retain);
-        return (pdu);
+        return pdu;
     }
 
     public static final ProtocolDataUnit createTMResponsePdu (TaskManagementFunctionResponseParser.ResponseCode response, int initiatorTaskTag) {
@@ -89,7 +89,7 @@ public class TargetPduFactory {
         final TaskManagementFunctionResponseParser parser = (TaskManagementFunctionResponseParser) bhs.getParser();
         parser.setResponse(response);
         bhs.setInitiatorTaskTag(initiatorTaskTag);
-        return (pdu);
+        return pdu;
     }
 
     public static final ProtocolDataUnit createReadyToTransferPdu (long logicalUnitNumber, int initiatorTaskTag, int targetTransferTag, int readyToTransferSequenceNumber, int bufferOffset, int desiredDataTransferLength) {

--- a/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/TextNegotiationStage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/TextNegotiationStage.java
@@ -80,7 +80,7 @@ public final class TextNegotiationStage extends TargetFullFeatureStage {
                 final boolean sendTargetName = // see upper table
                 !normal && sendTargetsValue.equals(TextKeyword.ALL);
                 final boolean sendTargetAddress = // see upper table
-                (!normal && sendTargetsValue.equals(TextKeyword.ALL)) || (session.getTargetServer().isValidTargetName(sendTargetsValue)) || (normal && sendTargetsValue.length() == 0);
+                (!normal && sendTargetsValue.equals(TextKeyword.ALL)) || session.getTargetServer().isValidTargetName(sendTargetsValue) || (normal && sendTargetsValue.length() == 0);
 
                 /*
                  * A target record consists of a TargetName key-value pair followed by one or more TargetAddress

--- a/bundles/target/src/main/java/org/jscsi/target/scsi/inquiry/DeviceIdentificationVpdPage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/scsi/inquiry/DeviceIdentificationVpdPage.java
@@ -96,7 +96,7 @@ public class DeviceIdentificationVpdPage implements IResponseData {
     private short getPageLength () {
         short pageLength = 0;
         for (int i = 0; i < identificationDescriptors.length; ++i) {
-            pageLength += (identificationDescriptors[i].size());
+            pageLength += identificationDescriptors[i].size();
         }
         return pageLength;
     }

--- a/bundles/target/src/main/java/org/jscsi/target/storage/FileStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/FileStorageModule.java
@@ -119,7 +119,7 @@ public class FileStorageModule implements IStorageModule {
             Files.write(new File(mBaseDir + File.separator + filePos).toPath(), cachedBytes);
 
             byte[] nextStep = new byte[bytes.length - (mFileSize - storageOffset)];
-            System.arraycopy(bytes, (mFileSize - storageOffset), nextStep, 0, bytes.length - (mFileSize - storageOffset));
+            System.arraycopy(bytes, mFileSize - storageOffset, nextStep, 0, bytes.length - (mFileSize - storageOffset));
             write(nextStep, storageIndex + (mFileSize - storageOffset));
         } else {
             System.arraycopy(bytes, 0, cachedBytes, storageOffset, bytes.length);

--- a/bundles/target/src/main/java/org/jscsi/target/storage/RandomAccessStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/RandomAccessStorageModule.java
@@ -121,7 +121,7 @@ public class RandomAccessStorageModule implements IStorageModule {
     public static synchronized final IStorageModule open (final File file, final long storageLength, final boolean create, Class<? extends IStorageModule> kind) throws IOException {
         long sizeInBlocks;
         sizeInBlocks = storageLength / VIRTUAL_BLOCK_SIZE;
-        if (create && !(kind.equals(JCloudsStorageModule.class))) {
+        if (create && !kind.equals(JCloudsStorageModule.class)) {
             createStorageVolume(file, storageLength);
         }
         // throws exc. if !file.exists()


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
