### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/bundles/target/src/main/java/org/jscsi/target/Configuration.java
+++ b/bundles/target/src/main/java/org/jscsi/target/Configuration.java
@@ -155,7 +155,7 @@ public class Configuration {
             targetAddress = pTargetAddress;
         }
 
-        targets = new ArrayList<Target>();
+        targets = new ArrayList<>();
     }
 
     public int getInMaxRecvTextPduSequenceLength () {

--- a/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
+++ b/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
@@ -54,7 +54,7 @@ public final class TargetServer implements Callable<Void> {
     /**
      * Contains all active {@link TargetSession}s.
      */
-    private Collection<TargetSession> sessions = new Vector<TargetSession>();
+    private Collection<TargetSession> sessions = new Vector<>();
 
     /**
      * The jSCSI Target's global parameters.
@@ -69,7 +69,7 @@ public final class TargetServer implements Callable<Void> {
     /**
      * The table of targets
      */
-    private HashMap<String , Target> targets = new HashMap<String , Target>();
+    private HashMap<String , Target> targets = new HashMap<>();
 
     /**
      * A target-wide counter used for providing the value of sent {@link ProtocolDataUnit}s'
@@ -139,7 +139,7 @@ public final class TargetServer implements Callable<Void> {
         Enumeration<NetworkInterface> interfaceEnum = NetworkInterface.getNetworkInterfaces();
         NetworkInterface i;
         int addressCounter = 0;
-        List<InetAddress> addresses = new ArrayList<InetAddress>();
+        List<InetAddress> addresses = new ArrayList<>();
         while (interfaceEnum.hasMoreElements()) {
             i = interfaceEnum.nextElement();
             Enumeration<InetAddress> addressEnum = i.getInetAddresses();

--- a/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/TextNegotiationStage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/TextNegotiationStage.java
@@ -52,7 +52,7 @@ public final class TextNegotiationStage extends TargetFullFeatureStage {
         // tokenize key-value pairs
         final List<String> requestKeyValuePairs = TextParameter.tokenizeKeyValuePairs(textRequest);
 
-        final List<String> responseKeyValuePairs = new Vector<String>();
+        final List<String> responseKeyValuePairs = new Vector<>();
 
         // process SendTargets command
         if (requestKeyValuePairs != null) {

--- a/bundles/target/src/main/java/org/jscsi/target/connection/stage/login/LoginOperationalParameterNegotiationStage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/stage/login/LoginOperationalParameterNegotiationStage.java
@@ -47,7 +47,7 @@ public final class LoginOperationalParameterNegotiationStage extends TargetLogin
 
         // negotiate parameters, leave if unsuccessful
         final List<String> requestKeyValuePairs = TextParameter.tokenizeKeyValuePairs(keyValuePairProposal);
-        final List<String> responseKeyValuePairs = new Vector<String>();
+        final List<String> responseKeyValuePairs = new Vector<>();
         if (!negotiator.negotiate(session.getTargetServer(), stageNumber, connection.isLeadingConnection(), ((TargetLoginPhase) targetPhase).getFirstPduAndSetToFalse(), requestKeyValuePairs, responseKeyValuePairs)) {
             // negotiation failure, no exception
             sendRejectPdu(LoginStatus.INITIATOR_ERROR);

--- a/bundles/target/src/main/java/org/jscsi/target/connection/stage/login/SecurityNegotiationStage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/stage/login/SecurityNegotiationStage.java
@@ -56,7 +56,7 @@ public final class SecurityNegotiationStage extends TargetLoginStage {
             final List<String> requestKeyValuePairs = TextParameter.tokenizeKeyValuePairs(requestTextParameters);
 
             // Vector for AuthMethod keys
-            final List<String> authMethodKeyValuePairs = new Vector<String>();
+            final List<String> authMethodKeyValuePairs = new Vector<>();
 
             // log initiator's key-value pairs
             if (LOGGER.isDebugEnabled()) {
@@ -104,7 +104,7 @@ public final class SecurityNegotiationStage extends TargetLoginStage {
             }
 
             // negotiate remaining parameters
-            final Vector<String> responseKeyValuePairs = new Vector<String>();// these
+            final Vector<String> responseKeyValuePairs = new Vector<>();// these
                                                                               // will
                                                                               // be
                                                                               // sent

--- a/bundles/target/src/main/java/org/jscsi/target/scsi/modeSense/ModePageCode.java
+++ b/bundles/target/src/main/java/org/jscsi/target/scsi/modeSense/ModePageCode.java
@@ -44,7 +44,7 @@ public enum ModePageCode {
      * 
      * @see #joinCodes(int, int)
      */
-    private static Map<Integer , ModePageCode> map = new HashMap<Integer , ModePageCode>();
+    private static Map<Integer , ModePageCode> map = new HashMap<>();
     static {// initialize map
         final ModePageCode[] modePages = values();
         for (ModePageCode mp : modePages)

--- a/bundles/target/src/main/java/org/jscsi/target/scsi/sense/AdditionalSenseCodeAndQualifier.java
+++ b/bundles/target/src/main/java/org/jscsi/target/scsi/sense/AdditionalSenseCodeAndQualifier.java
@@ -47,7 +47,7 @@ public enum AdditionalSenseCodeAndQualifier {
          * TODO replace ConcurrentHashMap with sorted array and use binary search. Has low priority since sense data is
          * not needed in properly working iSCSI exchanges.
          */
-        mapping = new ConcurrentHashMap<Short , AdditionalSenseCodeAndQualifier>();
+        mapping = new ConcurrentHashMap<>();
         for (AdditionalSenseCodeAndQualifier a : AdditionalSenseCodeAndQualifier.values())
             mapping.put(a.value, a);
     }

--- a/bundles/target/src/main/java/org/jscsi/target/settings/ConnectionSettingsNegotiator.java
+++ b/bundles/target/src/main/java/org/jscsi/target/settings/ConnectionSettingsNegotiator.java
@@ -131,8 +131,8 @@ public final class ConnectionSettingsNegotiator extends SettingsNegotiator {
     public boolean negotiate (TargetServer target, final LoginStage loginStage, final boolean leadingConnection, final boolean initialPdu, final List<String> requestKeyValuePairs, final List<String> responseKeyValuePairs) {
 
         // split up key=value pairs from requester
-        final List<String> keys = new Vector<String>();
-        final List<String> values = new Vector<String>();
+        final List<String> keys = new Vector<>();
+        final List<String> values = new Vector<>();
         for (String keyValuePair : requestKeyValuePairs) {
             final String[] split = TextParameter.splitKeyValuePair(keyValuePair);
             if (split == null) {

--- a/bundles/target/src/main/java/org/jscsi/target/settings/SettingsNegotiator.java
+++ b/bundles/target/src/main/java/org/jscsi/target/settings/SettingsNegotiator.java
@@ -22,7 +22,7 @@ public abstract class SettingsNegotiator {
      * <p>
      * These elements might change consecutively during parameter negotiations.
      */
-    protected List<Entry> entries = new ArrayList<Entry>();
+    protected List<Entry> entries = new ArrayList<>();
 
     /**
      * A back-up copy of the last consistent state of all elements in {@link #entries} or <code>null</code>.
@@ -54,7 +54,7 @@ public abstract class SettingsNegotiator {
      */
     protected static final List<Entry> copy (final List<Entry> entries) {
         if (entries == null) return null;
-        final ArrayList<Entry> copy = new ArrayList<Entry>();
+        final ArrayList<Entry> copy = new ArrayList<>();
         for (Entry e : entries)
             copy.add(e.copy());
         return copy;

--- a/bundles/target/src/main/java/org/jscsi/target/settings/TextParameter.java
+++ b/bundles/target/src/main/java/org/jscsi/target/settings/TextParameter.java
@@ -26,7 +26,7 @@ public final class TextParameter {
      * @return a {@link Vector} of {@link String}s containing the purged key value pairs
      */
     public static List<String> tokenizeKeyValuePairs (final String keyValuePairs) {
-        final List<String> result = new Vector<String>();
+        final List<String> result = new Vector<>();
         if (keyValuePairs == null) return result;
         final String[] split = keyValuePairs.split(TextKeyword.NULL_CHAR);
         for (int i = 0; i < split.length; ++i)
@@ -112,7 +112,7 @@ public final class TextParameter {
         if (a == null || b == null) return null;
         final int maxLength = Math.max(a.length, b.length);// prevent growing of
                                                            // the ArrayList
-        final ArrayList<String> intersection = new ArrayList<String>(maxLength);
+        final ArrayList<String> intersection = new ArrayList<>(maxLength);
         for (int i = 0; i < a.length; ++i) {
             for (int j = 0; j < b.length; ++j) {
                 if (a[i] == null || b[j] == null) return null;

--- a/bundles/target/src/main/java/org/jscsi/target/storage/JCloudsStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/JCloudsStorageModule.java
@@ -149,15 +149,15 @@ public class JCloudsStorageModule implements IStorageModule {
 
         final ExecutorService writerService = Executors.newFixedThreadPool(20);
         final ExecutorService readerService = Executors.newFixedThreadPool(20);
-        mRunningWriteTasks = new ConcurrentHashMap<Integer , Future<Integer>>();
-        mRunningReadTasks = new ConcurrentHashMap<Integer , Future<Map.Entry<Integer , byte[]>>>();
+        mRunningWriteTasks = new ConcurrentHashMap<>();
+        mRunningReadTasks = new ConcurrentHashMap<>();
 
-        mReaderService = new ExecutorCompletionService<Map.Entry<Integer , byte[]>>(readerService);
+        mReaderService = new ExecutorCompletionService<>(readerService);
         final Thread readHashmapCleaner = new Thread(new ReadFutureCleaner());
         readHashmapCleaner.setDaemon(true);
         readHashmapCleaner.start();
 
-        mWriterService = new ExecutorCompletionService<Integer>(writerService);
+        mWriterService = new ExecutorCompletionService<>(writerService);
         final Thread writeHashmapCleaner = new Thread(new WriteFutureCleaner());
         writeHashmapCleaner.setDaemon(true);
         writeHashmapCleaner.start();

--- a/bundles/target/src/test/java/org/jscsi/target/connection/ConnectionTest.java
+++ b/bundles/target/src/test/java/org/jscsi/target/connection/ConnectionTest.java
@@ -104,7 +104,7 @@ public class ConnectionTest {
         assertEquals(pStages.length, pDataUnits.length);
         assertEquals(pStages.length, pChecker.length);
 
-        List<ProtocolDataUnit> units = new ArrayList<ProtocolDataUnit>();
+        List<ProtocolDataUnit> units = new ArrayList<>();
 
         for (int i = 0; i < 8; i++) {
             pStages[i].execute(pDataUnits[i]);
@@ -424,7 +424,7 @@ public class ConnectionTest {
                 // tokenize key-value pairs
                 final List<String> requestKeyValuePairs = TextParameter.tokenizeKeyValuePairs(textRequest);
 
-                final List<String> responseKeyValuePairs = new Vector<String>();
+                final List<String> responseKeyValuePairs = new Vector<>();
 
                 // process SendTargets command
                 if (requestKeyValuePairs != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.