### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/bundles/target/src/main/java/org/jscsi/target/connection/TargetPduFactory.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/TargetPduFactory.java
@@ -37,6 +37,9 @@ public class TargetPduFactory {
      */
     private static final ProtocolDataUnitFactory factory = new ProtocolDataUnitFactory();
 
+    private TargetPduFactory() {
+    }
+
     public static final ProtocolDataUnit createDataInPdu (boolean finalFlag, boolean acknowledgeFlag, boolean residualOverflowFlag, boolean residualUnderflowFlag, boolean statusFlag, SCSIStatus status, long logicalUnitNumber, int initiatorTaskTag, int targetTransferTag, int dataSequenceNumber,//
             int bufferOffset, int residualCount, ByteBuffer dataSegment) {
         final ProtocolDataUnit pdu = factory.create(false, finalFlag, OperationCode.SCSI_DATA_IN, "None", "None");

--- a/bundles/target/src/main/java/org/jscsi/target/settings/TextKeyword.java
+++ b/bundles/target/src/main/java/org/jscsi/target/settings/TextKeyword.java
@@ -61,4 +61,6 @@ public final class TextKeyword {
     public static final String NULL_CHAR = Character.valueOf((char) 0).toString();
     public static final String COLON = ":";
 
+    private TextKeyword() {
+    }
 }

--- a/bundles/target/src/main/java/org/jscsi/target/settings/TextParameter.java
+++ b/bundles/target/src/main/java/org/jscsi/target/settings/TextParameter.java
@@ -16,6 +16,9 @@ import java.util.regex.Pattern;
  */
 public final class TextParameter {
 
+    private TextParameter() {
+    }
+
     /**
      * Returns the <i>key-value</i> pairs contained in a null character-separated text data segment in an array of
      * {@link String}s.

--- a/bundles/target/src/main/java/org/jscsi/target/util/BitManip.java
+++ b/bundles/target/src/main/java/org/jscsi/target/util/BitManip.java
@@ -12,6 +12,9 @@ package org.jscsi.target.util;
  */
 public final class BitManip {
 
+    private BitManip() {
+    }
+
     /**
      * Sets a single bit. If the <i>value</i> parameter is <code>true</code>, the bit will be set to <code>one</code>,
      * and to <code>zero</code> otherwise. All other bits will be left unchanged.

--- a/bundles/target/src/main/java/org/jscsi/target/util/Debug.java
+++ b/bundles/target/src/main/java/org/jscsi/target/util/Debug.java
@@ -17,6 +17,9 @@ public class Debug {
      */
     private static final int BYTES_PER_LINE = 4;
 
+    private Debug() {
+    }
+
     /**
      * Prints the <i>buffer</i> content to <code>System.out</code>.
      * 

--- a/bundles/target/src/main/java/org/jscsi/target/util/ReadWrite.java
+++ b/bundles/target/src/main/java/org/jscsi/target/util/ReadWrite.java
@@ -12,6 +12,9 @@ import java.nio.ByteBuffer;
  */
 public final class ReadWrite {
 
+    private ReadWrite() {
+    }
+
     /**
      * Reads a specified byte from a {@link ByteBuffer} and returns its value as an unsigned integer.
      * 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.