### PR TITLE
allowing different block size for storage modules

### DIFF
--- a/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/ModeSenseStage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/ModeSenseStage.java
@@ -1,8 +1,5 @@
 package org.jscsi.target.connection.stage.fullfeature;
 
-
-import static org.jscsi.target.storage.IStorageModule.VIRTUAL_BLOCK_SIZE;
-
 import java.io.IOException;
 import java.security.DigestException;
 
@@ -83,7 +80,7 @@ public final class ModeSenseStage extends TargetFullFeatureStage {
             // create ModeParameterList
             final ModeParameterListBuilder builder = new ModeParameterListBuilder(HeaderType.MODE_PARAMETER_HEADER_6);
             builder.setLogicalBlockDescriptors(new ShortLogicalBlockDescriptor(session.getStorageModule().getSizeInBlocks(),// numberOfLogicalBlocks
-            VIRTUAL_BLOCK_SIZE));// logicalBlockLength
+            session.getStorageModule().getBlockSize()));// logicalBlockLength
             builder.setModePages(modePages);
             ModeParameterList modeParameterList = ModeParameterList.build(builder);
 

--- a/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/ReadCapacityStage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/ReadCapacityStage.java
@@ -1,8 +1,5 @@
 package org.jscsi.target.connection.stage.fullfeature;
 
-
-import static org.jscsi.target.storage.IStorageModule.VIRTUAL_BLOCK_SIZE;
-
 import java.io.IOException;
 import java.security.DigestException;
 
@@ -79,10 +76,10 @@ public final class ReadCapacityStage extends TargetFullFeatureStage {
             ReadCapacityParameterData parameterData;
             if (cdb instanceof ReadCapacity10Cdb)
                 parameterData = new ReadCapacity10ParameterData(session.getStorageModule().getSizeInBlocks(),// returnedLogicalBlockAddress
-                VIRTUAL_BLOCK_SIZE);// logicalBlockLengthInBytes
+                session.getStorageModule().getBlockSize());// logicalBlockLengthInBytes
             else
                 parameterData = new ReadCapacity16ParameterData(session.getStorageModule().getSizeInBlocks(),// returnedLogicalBlockAddress
-                VIRTUAL_BLOCK_SIZE);// logicalBlockLengthInBytes
+                session.getStorageModule().getBlockSize());// logicalBlockLengthInBytes
 
             sendResponse(bhs.getInitiatorTaskTag(),// initiatorTaskTag,
                     parser.getExpectedDataTransferLength(),// expectedDataTransferLength,

--- a/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/ReadStage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/ReadStage.java
@@ -1,8 +1,5 @@
 package org.jscsi.target.connection.stage.fullfeature;
 
-
-import static org.jscsi.target.storage.IStorageModule.VIRTUAL_BLOCK_SIZE;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
@@ -83,12 +80,12 @@ public class ReadStage extends ReadOrWriteStage {
             return;
         }
 
-        final int totalTransferLength = VIRTUAL_BLOCK_SIZE * cdb.getTransferLength();
-        final long storageOffset = VIRTUAL_BLOCK_SIZE * cdb.getLogicalBlockAddress();
+        final int totalTransferLength = session.getStorageModule().getBlockSize() * cdb.getTransferLength();
+        final long storageOffset = session.getStorageModule().getBlockSize() * cdb.getLogicalBlockAddress();
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("cdb.getLogicalBlockAddress() = " + cdb.getLogicalBlockAddress());
-            LOGGER.debug("blockSize = " + VIRTUAL_BLOCK_SIZE);
+            LOGGER.debug("blockSize = " + session.getStorageModule().getBlockSize());
             LOGGER.debug("totalTransferLength = " + totalTransferLength);
             LOGGER.debug("expectedDataSegmentLength = " + parser.getExpectedDataTransferLength());
         }

--- a/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/WriteStage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/WriteStage.java
@@ -1,8 +1,5 @@
 package org.jscsi.target.connection.stage.fullfeature;
 
-
-import static org.jscsi.target.storage.IStorageModule.VIRTUAL_BLOCK_SIZE;
-
 import java.io.IOException;
 import java.security.DigestException;
 
@@ -106,8 +103,8 @@ public final class WriteStage extends ReadOrWriteStage {
         final long logicalBlockAddress = cdb.getLogicalBlockAddress();
 
         // transform to from block units to byte units
-        final int transferLengthInBytes = transferLength * VIRTUAL_BLOCK_SIZE;
-        long storageIndex = logicalBlockAddress * VIRTUAL_BLOCK_SIZE;
+        final int transferLengthInBytes = transferLength * session.getStorageModule().getBlockSize();
+        long storageIndex = logicalBlockAddress * session.getStorageModule().getBlockSize();
 
         // check if requested blocks are out of bounds
         // (might add FPSKSD to the CDB's list to be detected in the next step)

--- a/bundles/target/src/main/java/org/jscsi/target/storage/FileStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/FileStorageModule.java
@@ -33,6 +33,8 @@ public class FileStorageModule implements IStorageModule {
     /** How many file contents have to be cached. */
     private final int CACHE_SIZE;
 
+    private static final int VIRTUAL_BLOCK_SIZE = 512;
+
     /**
      * @param pBaseDir - The root directory for the filestorage (will be created if not exists)
      * @param pStorageSize - The size of the storage
@@ -165,6 +167,11 @@ public class FileStorageModule implements IStorageModule {
     @Override
     public void close () throws IOException {
         // Nothing to close, each bucket is opened individually.
+    }
+
+    @Override
+    public int getBlockSize() {
+        return VIRTUAL_BLOCK_SIZE;
     }
 
 }

--- a/bundles/target/src/main/java/org/jscsi/target/storage/IStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/IStorageModule.java
@@ -19,12 +19,6 @@ import org.jscsi.target.scsi.cdb.CommandDescriptorBlock;
  * @author Andreas Ergenzinger
  */
 public interface IStorageModule {
-
-    /**
-     * A fictitious block size.
-     */
-    public static final int VIRTUAL_BLOCK_SIZE = 512;
-
     /**
      * This method can be used for checking if a (series of) I/O operations will result in an {@link IOException} due to
      * trying to access blocks outside the medium's boundaries.
@@ -96,4 +90,10 @@ public interface IStorageModule {
      */
     void close () throws IOException;
 
+    /**
+     * Get block size of underlying storage medium.
+     *
+     * @return block size.
+     */
+    int getBlockSize();
 }

--- a/bundles/target/src/main/java/org/jscsi/target/storage/JCloudsStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/JCloudsStorageModule.java
@@ -86,6 +86,8 @@ public class JCloudsStorageModule implements IStorageModule {
     private static byte[] keyValue = new byte[] { 'k', 'k', 'k', 'k', 'k', 'k', 'k', 'k', 'k', 'k', 'k', 'k', 'k', 'k', 'k', 'k' };
     private static final Key KEY = new SecretKeySpec(keyValue, "AES");
 
+    private static final int VIRTUAL_BLOCK_SIZE = 512;
+
     /** Number of Bytes in Bucket. */
     public final static int SIZE_PER_BUCKET = BLOCK_IN_CLUSTER * VIRTUAL_BLOCK_SIZE;
 
@@ -317,6 +319,11 @@ public class JCloudsStorageModule implements IStorageModule {
     @Override
     public void close () throws IOException {
         mContext.close();
+    }
+
+    @Override
+    public int getBlockSize() {
+        return VIRTUAL_BLOCK_SIZE;
     }
 
     /**

--- a/bundles/target/src/main/java/org/jscsi/target/storage/RandomAccessStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/RandomAccessStorageModule.java
@@ -27,6 +27,8 @@ public class RandomAccessStorageModule implements IStorageModule {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RandomAccessStorageModule.class);
 
+    private static final int VIRTUAL_BLOCK_SIZE = 512;
+
     /**
      * The mode {@link String} parameter used during the instantiation of {@link #randomAccessFile}.
      * <p>
@@ -106,6 +108,11 @@ public class RandomAccessStorageModule implements IStorageModule {
      */
     public final void close () throws IOException {
         randomAccessFile.close();
+    }
+
+    @Override
+    public int getBlockSize() {
+        return VIRTUAL_BLOCK_SIZE;
     }
 
     /**

--- a/bundles/target/src/main/java/org/jscsi/target/storage/SynchronizedRandomAccessStorageModule.java
+++ b/bundles/target/src/main/java/org/jscsi/target/storage/SynchronizedRandomAccessStorageModule.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 
 public class SynchronizedRandomAccessStorageModule extends RandomAccessStorageModule implements IStorageModule {
 
+    private static final int VIRTUAL_BLOCK_SIZE = 512;
+
     public SynchronizedRandomAccessStorageModule (long sizeInBlocks, File file) throws FileNotFoundException {
         super(sizeInBlocks, file);
     }
@@ -20,6 +22,11 @@ public class SynchronizedRandomAccessStorageModule extends RandomAccessStorageMo
     @Override
     public synchronized void write (byte[] bytes, long storageIndex) throws IOException {
         super.write(bytes, storageIndex);
+    }
+
+    @Override
+    public int getBlockSize() {
+        return VIRTUAL_BLOCK_SIZE;
     }
 
 }


### PR DESCRIPTION
This commit changes IStorageModule to allow its implementations to have varying block sizes, instead of having a hard coded value of 512B.

Since the hard coded 512B is removed, also changed existing implementations that depends on this value to have this value internally.