### PR TITLE
inheritable target server

### DIFF
--- a/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
+++ b/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class TargetServer implements Callable<Void> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TargetServer.class);
+    protected static final Logger LOGGER = LoggerFactory.getLogger(TargetServer.class);
 
     /**
      * A {@link SocketChannel} used for listening to incoming connections.
@@ -69,7 +69,7 @@ public final class TargetServer implements Callable<Void> {
     /**
      * The table of targets
      */
-    private HashMap<String , Target> targets = new HashMap<>();
+    protected HashMap<String , Target> targets = new HashMap<>();
 
     /**
      * A target-wide counter used for providing the value of sent {@link ProtocolDataUnit}s'


### PR DESCRIPTION
Make the core data structure of target server protected protected instead of private, such that target server can be inherited and further customized.