### PR TITLE
removed final from target server

### DIFF
--- a/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
+++ b/bundles/target/src/main/java/org/jscsi/target/TargetServer.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * @author Andreas Ergenzinger, University of Konstanz
  * @author Sebastian Graf, University of Konstanz
  */
-public final class TargetServer implements Callable<Void> {
+public class TargetServer implements Callable<Void> {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(TargetServer.class);
 


### PR DESCRIPTION
One more that needs to be done to make TargetServer inheritable is to remove the key word final from class declaration.