### PR TITLE
Make the ip/port configurable for discovery

### DIFF
--- a/bundles/target/src/main/java/org/jscsi/target/Configuration.java
+++ b/bundles/target/src/main/java/org/jscsi/target/Configuration.java
@@ -270,23 +270,29 @@ public class Configuration {
         // else it is null
 
         // port
-        if (root.getElementsByTagName(ELEMENT_PORT).getLength() > 0)
-            returnConfiguration.port = Integer.parseInt(root.getElementsByTagName(ELEMENT_PORT).item(0).getTextContent());
-        else
+        NodeList portTags = root.getElementsByTagName(ELEMENT_PORT);
+        if (portTags.getLength() > 0) {
+            returnConfiguration.port = Integer.parseInt(portTags.item(0).getTextContent());
+        } else {
             returnConfiguration.port = 3260;
+        }
 
         // external port
-        if (root.getElementsByTagName(ELEMENT_EXTERNAL_PORT).getLength() > 0)
-            returnConfiguration.externalPort = Integer.parseInt(root.getElementsByTagName(ELEMENT_EXTERNAL_PORT).item(0).getTextContent());
-        else
+        NodeList externalPortTags = root.getElementsByTagName(ELEMENT_EXTERNAL_PORT);
+        if (externalPortTags.getLength() > 0) {
+            returnConfiguration.externalPort = Integer.parseInt(externalPortTags.item(0).getTextContent());
+        } else {
             returnConfiguration.externalPort = returnConfiguration.port;
+        }
 
 
         // external address
-        if (root.getElementsByTagName(ELEMENT_EXTERNAL_ADDRESS).getLength() > 0)
-            returnConfiguration.externalTargetAddress = root.getElementsByTagName(ELEMENT_EXTERNAL_ADDRESS).item(0).getTextContent();
-        else
+        NodeList externalAddressTAgs = root.getElementsByTagName(ELEMENT_EXTERNAL_ADDRESS);
+        if (externalAddressTAgs.getLength() > 0) {
+            returnConfiguration.externalTargetAddress = externalAddressTAgs.item(0).getTextContent();
+        } else {
             returnConfiguration.externalTargetAddress = pTargetAddress;
+        }
 
 
         // support sloppy text parameter negotiation (i.e. the jSCSI Initiator)?

--- a/bundles/target/src/main/java/org/jscsi/target/Configuration.java
+++ b/bundles/target/src/main/java/org/jscsi/target/Configuration.java
@@ -1,14 +1,14 @@
 package org.jscsi.target;
 
 
-import org.jscsi.target.scsi.lun.LogicalUnitNumber;
-import org.jscsi.target.settings.TextKeyword;
-import org.jscsi.target.storage.IStorageModule;
-import org.jscsi.target.storage.JCloudsStorageModule;
-import org.jscsi.target.storage.RandomAccessStorageModule;
-import org.jscsi.target.storage.SynchronizedRandomAccessStorageModule;
-import org.w3c.dom.*;
-import org.xml.sax.SAXException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
@@ -20,14 +20,19 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.List;
+
+import org.jscsi.target.scsi.lun.LogicalUnitNumber;
+import org.jscsi.target.settings.TextKeyword;
+import org.jscsi.target.storage.IStorageModule;
+import org.jscsi.target.storage.JCloudsStorageModule;
+import org.jscsi.target.storage.RandomAccessStorageModule;
+import org.jscsi.target.storage.SynchronizedRandomAccessStorageModule;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+import org.xml.sax.SAXException;
 
 
 /**

--- a/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/TextNegotiationStage.java
+++ b/bundles/target/src/main/java/org/jscsi/target/connection/stage/fullfeature/TextNegotiationStage.java
@@ -92,17 +92,17 @@ public final class TextNegotiationStage extends TargetFullFeatureStage {
                     for (String curTargetName : session.getTargetServer().getTargetNames()) {
                         responseKeyValuePairs.add(TextParameter.toKeyValuePair(TextKeyword.TARGET_NAME, curTargetName));
                         // add TargetAddress
-                        if (sendTargetAddress) responseKeyValuePairs.add(TextParameter.toKeyValuePair(TextKeyword.TARGET_ADDRESS, session.getTargetServer().getConfig().getTargetAddress() + // domain
+                        if (sendTargetAddress) responseKeyValuePairs.add(TextParameter.toKeyValuePair(TextKeyword.TARGET_ADDRESS, session.getTargetServer().getConfig().getExternalTargetAddress() + // domain
                         TextKeyword.COLON + // :
-                        session.getTargetServer().getConfig().getPort() + // port
+                        session.getTargetServer().getConfig().getExternalPort() + // port
                         TextKeyword.COMMA + // ,
                         session.getTargetServer().getConfig().getTargetPortalGroupTag())); // groupTag)
                     }
                 } else {
                     // We're here if they sent us a target name and are asking for the address (I think)
-                    if (sendTargetAddress) responseKeyValuePairs.add(TextParameter.toKeyValuePair(TextKeyword.TARGET_ADDRESS, session.getTargetServer().getConfig().getTargetAddress() + // domain
+                    if (sendTargetAddress) responseKeyValuePairs.add(TextParameter.toKeyValuePair(TextKeyword.TARGET_ADDRESS, session.getTargetServer().getConfig().getExternalTargetAddress() + // domain
                     TextKeyword.COLON + // :
-                    session.getTargetServer().getConfig().getPort() + // port
+                    session.getTargetServer().getConfig().getExternalPort() + // port
                     TextKeyword.COMMA + // ,
                     session.getTargetServer().getConfig().getTargetPortalGroupTag())); // groupTag)
                 }

--- a/bundles/target/src/test/resources/jscsi-target.xsd
+++ b/bundles/target/src/test/resources/jscsi-target.xsd
@@ -92,6 +92,10 @@
                 default="false" minOccurs="0" maxOccurs="1" />
             <xs:element name="Port" type="TargetPortType"
                 default="3260" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ExternalPort" type="TargetPortType"
+                        minOccurs="0" maxOccurs="1" />
+            <xs:element name="ExternalAddress" type="TargetPortType"
+                        minOccurs="0" maxOccurs="1" />
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
The current code returns with the target address and port (3260) in case of iscsi discovery. But in some cases this is not the right data.

For example running jscsi server in kubernetes, the external ip/port could be different from the listening address. In kubernetes cluster the services could have a cluster wide ip. In that case even if the jscsi server listens on 0.0.0.0 a different external ip should returned during the discovery.

Same is true for the port. In some cases (behind a load balancer/tcp proxy) the external port could be different from the listening port.

This patch propose a simple configuration to override to announced ip/port.

The patch is tested with HDFS cluster in kubernetes environment with this patch: https://issues.apache.org/jira/browse/HDFS-13018 (And this modification is needed to successfull run hdfs/cblock clusters in kubernetes).